### PR TITLE
Add support for subdomains containing hyphens

### DIFF
--- a/certbot_dns_duckdns/duckdns/client.py
+++ b/certbot_dns_duckdns/duckdns/client.py
@@ -6,7 +6,7 @@ import requests
 
 BASE_URL = "https://www.duckdns.org/update"
 DNS_RESOLVE_BASE_URL = "https://dns.google/resolve?type=TXT"
-VALID_DUCKDNS_DOMAIN_REGEX = re.compile("^[a-z0-9]+(.duckdns.org)?$")
+VALID_DUCKDNS_DOMAIN_REGEX = re.compile("^[a-z0-9\\-]+(.duckdns.org)?$")
 
 
 class TXTUpdateError(Exception):


### PR DESCRIPTION
An assert for the regex fix failed for subdomains where a hyphen is included in the name. Hyphens are allowed in subdomains so the regex should allow these.