### PR TITLE
Ease up deps for dnspython and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools~=57.0.0
-requests~=2.26.0
+requests~=2.26
 certbot>=1.7.0
 zope.interface~=5.4.0
-dnspython~=2.1.0
+dnspython~=2.1

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     install_requires=[
         "zope.interface~=5.4.0",
         "certbot>=1.7.0",
-        "requests~=2.26.0",
-        "dnspython~=2.1.0"
+        "requests~=2.26",
+        "dnspython~=2.1"
     ],
     entry_points={
         "certbot.plugins": [


### PR DESCRIPTION
Some distributions don't package the exact versions certbot-dns-duckdns currently depends on. Therefore, don't pin the dependency minor version to an exact number, but also allow newer minor versions.

In this case specifically, Gentoo recently removed dnspython-2.1.0 and only has 2.2.0 packaged and also removed requests-2.26.0, but is packaging 2.27.0 now. Removing the versions patch number from the `~=` operator allows Python to accept any minor version number newer than the one specified while forcing the major version number to be the same as the one specified.

Fixes #26.