### PR TITLE
Nobody84 feature handle delegated acme challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,4 @@ dmypy.json
 test_certbot
 *.ini
 *.snap
+*.vscode

--- a/certbot_dns_duckdns/cert/client.py
+++ b/certbot_dns_duckdns/cert/client.py
@@ -134,7 +134,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         :return: the duckdns.org subdomain
         """
 
-        # valid duckdns.org domain
+        # valid duckdns.org subdomain
         if VALID_DUCKDNS_DOMAIN_REGEX.match(domain) != None:
             return domain
 
@@ -143,17 +143,17 @@ class Authenticator(dns_common.DNSAuthenticator):
             result = resolver.resolve("_acme-challenge." + domain, 'A')
             return result.canonical_name.to_text().rstrip('.')
         except (resolver.NXDOMAIN, resolver.NoAnswer) as e:
-            errors.PluginError(e)
+            pass
 
         # delegated acme challenge (ipv6)
         try:
             result = resolver.resolve("_acme-challenge." + domain, 'AAAA')
             return result.canonical_name.to_text().rstrip('.')
         except (resolver.NXDOMAIN, resolver.NoAnswer) as e:
-            errors.PluginError(e)
+            pass
 
         
         # invalid domain
-        e = Exception("The given domain \"{}\" is neither a duckdns.org subdomain nor " +
-                      " delegates _acme-challenge.{} to a duckdns.org subdomain.".format(domain, domain))
+        e = Exception("The given domain \"{}\" is neither a duckdns subdomain nor " +
+                      " delegates _acme-challenge.{} to a duckdns subdomain.".format(domain, domain))
         errors.PluginError(e)

--- a/certbot_dns_duckdns/cert/client.py
+++ b/certbot_dns_duckdns/cert/client.py
@@ -75,11 +75,14 @@ class Authenticator(dns_common.DNSAuthenticator):
         :raise PluginError: if the TXT record can not be set of something goes wrong
         """
 
+        # get the duckdns domain
+        duckdns_domain = self._get_duckdns_domain(domain)
+
         if not self.conf("no-txt-restore"):
             # get the current TXT record
             custom_resolver = resolver.Resolver()
             try:
-                txt_values = custom_resolver.resolve(domain, "TXT")
+                txt_values = custom_resolver.resolve(duckdns_domain, "TXT")
             except Exception as e:
                 raise errors.PluginError(e)
 
@@ -91,7 +94,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             self.old_txt_value = txt_values[0].to_text()[1:-1]
 
         try:
-            self._get_duckdns_client().set_txt_record(domain, validation)
+            self._get_duckdns_client().set_txt_record(duckdns_domain, validation)
         except Exception as e:
             raise errors.PluginError(e)
 
@@ -105,13 +108,16 @@ class Authenticator(dns_common.DNSAuthenticator):
         :param validation: the value for the TXT record
         :raise PluginError:  if the TXT record can not be cleared of something goes wrong
         """
+        
+        # get the duckdns domain
+        duckdns_domain = self._get_duckdns_domain(domain)
 
         try:
             if self.old_txt_value == "":
                 # setting an empty TXT value does not work with the DuckDNS API
-                self._get_duckdns_client().clear_txt_record(domain)
+                self._get_duckdns_client().clear_txt_record(duckdns_domain)
             else:
-                self._get_duckdns_client().set_txt_record(domain, self.old_txt_value)
+                self._get_duckdns_client().set_txt_record(duckdns_domain, self.old_txt_value)
         except Exception as e:
             raise errors.PluginError(e)
 

--- a/certbot_dns_duckdns/duckdns/client.py
+++ b/certbot_dns_duckdns/duckdns/client.py
@@ -8,7 +8,7 @@ from dns import resolver
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 BASE_URL = "https://www.duckdns.org/update"
-from certbot_dns_duckdns.cert.client import VALID_DUCKDNS_DOMAIN_REGEX
+VALID_DUCKDNS_DOMAIN_REGEX = re.compile("^[a-z0-9\\-]+(.duckdns.org)?$")
 
 class TXTUpdateError(Exception):
     """

--- a/certbot_dns_duckdns/duckdns/client.py
+++ b/certbot_dns_duckdns/duckdns/client.py
@@ -8,8 +8,7 @@ from dns import resolver
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 BASE_URL = "https://www.duckdns.org/update"
-VALID_DUCKDNS_DOMAIN_REGEX = re.compile("^[a-z0-9\\-]+(.duckdns.org)?$")
-
+from certbot_dns_duckdns.cert.client import VALID_DUCKDNS_DOMAIN_REGEX
 
 class TXTUpdateError(Exception):
     """
@@ -64,18 +63,9 @@ class DuckDNSClient:
         # get the root domain with the first subdomain
         domain_parts = domain.split(".")
         root_domain = ".".join(domain_parts[-3:])
-
-        # if the root domain is not a duckdns.org domain, check if it delegates the acme challenge and resolve the resulting CNAME.
-        # see delegated acme challenge https://letsencrypt.org/docs/challenge-types/#dns-01-challenge
-        if VALID_DUCKDNS_DOMAIN_REGEX.match(root_domain) == None:
-            result = resolver.resolve("_acme-challenge." + domain, 'A')
-            root_domain = result.canonical_name.to_text().rstrip('.') # Nobody84: In my testing the canonical name end with a '.' like 'example.duckdns.org.' 
-        
         assert VALID_DUCKDNS_DOMAIN_REGEX.match(root_domain)
 
         return root_domain
-
-
 
     def clear_txt_record(self, domain: str) -> None:
         """

--- a/certbot_dns_duckdns/duckdns/client.py
+++ b/certbot_dns_duckdns/duckdns/client.py
@@ -69,7 +69,7 @@ class DuckDNSClient:
         # see delegated acme challenge https://letsencrypt.org/docs/challenge-types/#dns-01-challenge
         if VALID_DUCKDNS_DOMAIN_REGEX.match(root_domain) == None:
             result = resolver.resolve("_acme-challenge." + domain, 'A')
-            root_domain = result.canonical_name.to_text().rstrip('.') # Nobody_84: In my testing the canonical name end with a '.' like 'example.duckdns.org.' 
+            root_domain = result.canonical_name.to_text().rstrip('.') # Nobody84: In my testing the canonical name end with a '.' like 'example.duckdns.org.' 
         
         assert VALID_DUCKDNS_DOMAIN_REGEX.match(root_domain)
 

--- a/tests/duckdns_tests.py
+++ b/tests/duckdns_tests.py
@@ -8,7 +8,6 @@ from dns.resolver import Resolver
 from certbot_dns_duckdns.cert.client import DEFAULT_PROPAGATION_SECONDS
 from certbot_dns_duckdns.duckdns.client import DuckDNSClient, TXTUpdateError
 
-TEST_DELEGATING_DOMAIN = os.environ.get("TEST_DELEGATING_DOMAIN")
 TEST_DOMAIN = os.environ.get("TEST_DOMAIN")
 TEST_DUCKDNS_TOKEN = os.environ.get("TEST_DUCKDNS_TOKEN")
 
@@ -167,7 +166,7 @@ class DuckDNSTests(unittest.TestCase):
         with self.subTest():
             root_domain = DuckDNSClient.__get_validated_root_domain__("-123ad-sdas--45-as-." + TEST_DOMAIN)
             self.assertEqual(root_domain, TEST_DOMAIN)
-            
+
     def test_clear_txt(self):
         duckdns_client = DuckDNSClient(TEST_DUCKDNS_TOKEN)
 

--- a/tests/duckdns_tests.py
+++ b/tests/duckdns_tests.py
@@ -167,11 +167,7 @@ class DuckDNSTests(unittest.TestCase):
         with self.subTest():
             root_domain = DuckDNSClient.__get_validated_root_domain__("-123ad-sdas--45-as-." + TEST_DOMAIN)
             self.assertEqual(root_domain, TEST_DOMAIN)
-
-    def test_get_validated_root_domain_delegated_acme_challenge(self):
-        with self.subTest():
-            root_domain = DuckDNSClient.__get_validated_root_domain__(TEST_DELEGATING_DOMAIN)
-            self.assertEqual(root_domain, TEST_DOMAIN)
+            
     def test_clear_txt(self):
         duckdns_client = DuckDNSClient(TEST_DUCKDNS_TOKEN)
 

--- a/tests/duckdns_tests.py
+++ b/tests/duckdns_tests.py
@@ -8,6 +8,7 @@ from dns.resolver import Resolver
 from certbot_dns_duckdns.cert.client import DEFAULT_PROPAGATION_SECONDS
 from certbot_dns_duckdns.duckdns.client import DuckDNSClient, TXTUpdateError
 
+TEST_DELEGATING_DOMAIN = os.environ.get("TEST_DELEGATING_DOMAIN")
 TEST_DOMAIN = os.environ.get("TEST_DOMAIN")
 TEST_DUCKDNS_TOKEN = os.environ.get("TEST_DUCKDNS_TOKEN")
 
@@ -167,6 +168,10 @@ class DuckDNSTests(unittest.TestCase):
             root_domain = DuckDNSClient.__get_validated_root_domain__("-123ad-sdas--45-as-." + TEST_DOMAIN)
             self.assertEqual(root_domain, TEST_DOMAIN)
 
+    def test_get_validated_root_domain_delegated_acme_challenge(self):
+        with self.subTest():
+            root_domain = DuckDNSClient.__get_validated_root_domain__(TEST_DELEGATING_DOMAIN)
+            self.assertEqual(root_domain, TEST_DOMAIN)
     def test_clear_txt(self):
         duckdns_client = DuckDNSClient(TEST_DUCKDNS_TOKEN)
 


### PR DESCRIPTION
The changes allow the plugin to work with domains that delegate the acme challenge to duckdns.org.
See [https://letsencrypt.org/docs/challenge-types/#dns-01-challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)

E.g. if the DNS records look like:
| name | type | value |
| ------------- | ------------- |------------- |
| subdomain.example.com | A  | 1.2.3.4 |
| _acme-challenge.subdomain.example.com  | CNAME  | subdomain.duckdns.org |

You can use the plugin with 'subdomain.example.com' and the txt record of 'subdomain.duckdns.org' will be updated. 