### PR TITLE
remove zope

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -385,7 +385,6 @@ All modules used by this project are listed below:
 |:------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------:|
 | [certbot](https://github.com/certbot/certbot)                      | [Apache 2.0](https://raw.githubusercontent.com/certbot/certbot/master/LICENSE.txt)            |
 | [requests](https://github.com/psf/requests)                        | [Apache 2.0](https://raw.githubusercontent.com/psf/requests/master/LICENSE)                   |
-| [zope.interface](https://github.com/zopefoundation/zope.interface) | [ZPL-2.1](https://raw.githubusercontent.com/zopefoundation/zope.interface/master/LICENSE.txt) |
 | [setuptools](https://github.com/pypa/setuptools)                   | [MIT](https://raw.githubusercontent.com/pypa/setuptools/main/LICENSE)                         |
 | [dnspython](https://github.com/rthalley/dnspython)                 | [ISC](https://raw.githubusercontent.com/rthalley/dnspython/master/LICENSE)                    |
 

--- a/certbot_dns_duckdns/cert/client.py
+++ b/certbot_dns_duckdns/cert/client.py
@@ -1,5 +1,4 @@
-import zope.interface
-from certbot import errors, interfaces
+from certbot import errors
 from certbot.plugins import dns_common
 from dns import resolver
 
@@ -11,8 +10,6 @@ TXT_MAX_LEN = 255
 ACME_CHALLENGE_TXT_PREFIX = "_acme-challenge"
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """
     Authenticator class to handle dns-01 challenge for DuckDNS domains.

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,6 +1,5 @@
 setuptools~=60.10
 requests~=2.27
 certbot>=1.7.0
-zope.interface~=5.4.0
 dnspython~=2.2
 cryptography<=3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 setuptools~=60.10
 requests~=2.27
 certbot>=1.7.0
-zope.interface~=5.4.0
 dnspython~=2.2

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     packages=find_packages(),
     python_requires=">=3.7",
     install_requires=[
-        "zope.interface~=5.4.0",
         "certbot>=1.7.0",
         "requests~=2.26",
         "dnspython~=2.1"

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -1,3 +1,2 @@
 requests~=2.27
-zope.interface~=5.4.0
 dnspython~=2.2

--- a/third-party-notices
+++ b/third-party-notices
@@ -404,63 +404,6 @@ Copyright 2019 Kenneth Reitz
 
 
 ###########################################################################################
-## zope.interface: ##
-
-License:
-
-Zope Public License (ZPL) Version 2.1
-
-A copyright notice accompanies this license document that identifies the
-copyright holders.
-
-This license has been certified as open source. It has also been designated as
-GPL compatible by the Free Software Foundation (FSF).
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions in source code must retain the accompanying copyright
-notice, this list of conditions, and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the accompanying copyright
-notice, this list of conditions, and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Names of the copyright holders must not be used to endorse or promote
-products derived from this software without prior written permission from the
-copyright holders.
-
-4. The right to distribute this software or to use it for any purpose does not
-give you the right to use Servicemarks (sm) or Trademarks (tm) of the
-copyright
-holders. Use of them is covered by separate agreement with the copyright
-holders.
-
-5. If any files are modified, you must cause the modified files to carry
-prominent notices stating that you changed the files and the date of any
-change.
-
-Disclaimer
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY EXPRESSED
-OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
-EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Notice:
-
-Zope Foundation and Contributors
-
-###########################################################################################
-
-
-###########################################################################################
 ## setuptools: ##
 
 License:


### PR DESCRIPTION
zope has been deprecated since the release of Certbot 1.19.0 and the referenced interfaces will be removed in an upcoming version of Certbot.