### PR TITLE
Adjust linting and improve code quality

### DIFF
--- a/.github/workflows/formatting_check.yml
+++ b/.github/workflows/formatting_check.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install requirements
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Check formatting
         run: ruff format --check

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,3 @@
-
 name: linting
 
 on:
@@ -10,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,16 +28,16 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Lint with flake8
-        run: flake8 certbot_dns_duckdns --count --select=E9,F63,F7,F82 --show-source --statistics
+        run: flake8 certbot_dns_duckdns --count --ignore E501 --show-source --statistics
 
       - name: Lint with pylint
-        run: pylint certbot_dns_duckdns -d C,R,W
+        run: pylint certbot_dns_duckdns --disable C0301
 
   linting-setup-install:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"  ]
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +56,7 @@ jobs:
         run: pip install .
 
       - name: Lint with flake8
-        run: flake8 certbot_dns_duckdns --count --select=E9,F63,F7,F82 --show-source --statistics
+        run: flake8 certbot_dns_duckdns --count --ignore E501 --show-source --statistics
 
       - name: Lint with pylint
-        run: pylint certbot_dns_duckdns -d C,R,W
+        run: pylint certbot_dns_duckdns --disable C0301

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  linting-requirements-install:
+  linting:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,41 +19,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: install linting requirements
-        run: |
-          pip install --upgrade pip
-          pip install flake8 pylint
-
       - name: Install project requirements
-        run: pip install -r requirements.txt
-
-      - name: Lint with flake8
-        run: flake8 certbot_dns_duckdns --count --ignore E501 --show-source --statistics
-
-      - name: Lint with pylint
-        run: pylint certbot_dns_duckdns --disable C0301
-
-  linting-setup-install:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"  ]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: install linting requirements
-        run: |
-          pip install --upgrade pip
-          pip install flake8 pylint
-
-      - name: Install project
-        run: pip install .
+        run: pip install -r requirements-dev.txt
 
       - name: Lint with flake8
         run: flake8 certbot_dns_duckdns --count --ignore E501 --show-source --statistics

--- a/Readme.md
+++ b/Readme.md
@@ -407,7 +407,7 @@ You can the FAQ in the [wiki](https://github.com/infinityofspace/certbot_dns_duc
 First get the source code:
 
 ```commandline
-git clone https://github.com/infinityofspace/certbot_dns_porkbun.git
+git clone https://github.com/infinityofspace/certbot_dns_duckdns.git
 cd certbot_dns_porkbun
 ```
 
@@ -416,7 +416,7 @@ Now create a virtual environment, activate it and install all dependencies with 
 ```commandline
 python3 -m venv venv
 source venv/bin/activate
-pip3 install -r requirements.txt
+pip3 install -r requirements-dev.txt
 ```
 
 Now you can start developing.
@@ -427,6 +427,11 @@ commands to check/fulfill the requirements):
 
 - check unit tests: `python -m unittest tests/*.py`
 - format the code: `ruff format`
+- lint the code:
+```commandline
+flake8 certbot_dns_duckdns --count --ignore E501 --show-source --statistics
+pylint certbot_dns_duckdns --disable C0301
+```
 
 #### Tests
 

--- a/certbot_dns_duckdns/__init__.py
+++ b/certbot_dns_duckdns/__init__.py
@@ -1,1 +1,3 @@
+"""Certbot plugin for DNS-01 challenge using DuckDNS."""
+
 __version__ = "v1.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+responses~=0.25
+ruff~=0.7
+flake8~=7.1
+pylint~=3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ setuptools>=41.6.0
 requests>=2.20.0,<3.0
 certbot>=1.18.0,<4.0
 dnspython>=2.0.0,<3.0
-responses~=0.25
-ruff~=0.7


### PR DESCRIPTION
Improve the overall code quality by properly using linting:
- simplified linting workflow by using only a single job matrix
- separated dev and prod dependencies to reduce the docker image size and general pip install size
- enabled more linting flake8 rules instead of only a very small subset
- improved the `TXTUpdateError` to contain all required information to handle the exception
- moved some internal object fields to private state