### PR TITLE
Exclude tests from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Topic :: Utilities",
         "Topic :: System :: Systems Administration",
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.9",
     install_requires=[
         "certbot>=1.18.0,<4.0",


### PR DESCRIPTION
Reported by rpmlint:

```
python-tests-in-site-packages /usr/lib/python3.13/site-packages/tests
test/ or tests/ directory in %{python_sitelib}. This should never happen since
this is a global name space not owned by any particular package.
```