### PR TITLE
Use legacy dnspython resolver method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>=41.6.0
 requests>=2.20.0,<3.0
 certbot>=1.18.0,<4.0
-dnspython>=2.0.0,<3.0
+dnspython>=1.15.0,<3.0


### PR DESCRIPTION
Some non-rolling Linux distributions are still using dnspython 1.x in their repository, it allows this project to be packaged for them. the [legacy method](https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.query) has no indication of removal in the documentation, while provides the same functionality for this project.