### PR TITLE
README typo|missing verb

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -398,7 +398,7 @@ Obtain certificates using a DNS TXT record for DuckDNS domains
 
 ### FAQ
 
-You can the FAQ in the [wiki](https://github.com/infinityofspace/certbot_dns_duckdns/wiki/FAQ).
+You can read the FAQ in the [wiki](https://github.com/infinityofspace/certbot_dns_duckdns/wiki/FAQ).
 
 ### Development
 


### PR DESCRIPTION
Added the missing "read", can be "check" or "consult" or something similar at the end of the README > FAQ section
"You can >>READ<< the FAQ in the _link_"